### PR TITLE
Fix crash on launch

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.daemon=false
 ## Environment Properties
 
 minecraft_version=1.21
-minecraft_version_range=[1.21,1.21)
+minecraft_version_range=[1.21,1.22)
 forge_version=51.0.8
 forge_version_range=[0,)
 loader_version_range=[0,)


### PR DESCRIPTION
Someone on [the new Forge discord](<https://discord.minecraftforge.net>) was having trouble with a mod crashing their game on launch. After further investigation, they found that your mod is requesting an impossible version range (simultaneously requiring an MC version higher than 1.21 as well as below 1.21).

This PR should fix that issue.